### PR TITLE
Hotfix/fixing socket leak

### DIFF
--- a/src/Unleash/DefaultHttpClientFactory.cs
+++ b/src/Unleash/DefaultHttpClientFactory.cs
@@ -36,7 +36,7 @@ namespace Unleash
 
             return _httpClientCache.GetOrAdd(key, k =>
             {
-                var client = new HttpClient()
+                var client = new HttpClient
                 {
                     BaseAddress = unleashApiUri,
                     Timeout = Timeout

--- a/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
@@ -9,15 +9,15 @@ namespace Unleash.Tests.Communication
 
         private readonly Uri newApiUri = new Uri("http://unleash2.herokuapp2.com/");
 
-        private DefaultHttpClientFactory _httpClientFactory { get; } = new DefaultHttpClientFactory();
+        private readonly DefaultHttpClientFactory httpClientFactory = new DefaultHttpClientFactory();
 
         [Test]
         public void HttpClientFactory_Should_Create_Single_Instance_By_Dns_Success()
         {
-            var httpClient = _httpClientFactory.Create(apiUri);
+            var httpClient = httpClientFactory.Create(apiUri);
             var expectedHashId = httpClient.GetHashCode();
 
-            var newHttpClient = _httpClientFactory.Create(apiUri);
+            var newHttpClient = httpClientFactory.Create(apiUri);
             var actualHashId = newHttpClient.GetHashCode();
 
             Assert.AreEqual(expectedHashId, actualHashId);
@@ -26,10 +26,10 @@ namespace Unleash.Tests.Communication
         [Test]
         public void HttpClientFactory_Should_Create_One_Instance_Per_Dns_Success()
         {
-            var httpClient = _httpClientFactory.Create(apiUri);
+            var httpClient = httpClientFactory.Create(apiUri);
             var expectedHashId = httpClient.GetHashCode();
 
-            var newHttpClient = _httpClientFactory.Create(newApiUri);
+            var newHttpClient = httpClientFactory.Create(newApiUri);
             var actualHashId = newHttpClient.GetHashCode();
 
             Assert.AreNotEqual(expectedHashId, actualHashId);

--- a/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Unleash.Tests.Communication
+{
+    public class UnleashHttpClientFactory_RegisterHttpClient_Tests
+    {
+        private Uri _apiUri { get; } = new Uri("http://unleash.herokuapp.com/");
+
+        private Uri _newApiUri { get; } = new Uri("http://unleash2.herokuapp2.com/");
+
+        private DefaultHttpClientFactory _httpClientFactory { get; } = new DefaultHttpClientFactory();
+        [Test]
+        public void HttpClientFactory_Should_Create_Single_Instance_By_Dns_Success()
+        {
+
+            var httpClient = _httpClientFactory.Create(_apiUri);
+            var expectedHashId = httpClient.GetHashCode();
+
+            var newHttpClient = _httpClientFactory.Create(_apiUri);
+            var actualHashId = newHttpClient.GetHashCode();
+
+            Assert.AreEqual(expectedHashId, actualHashId);
+        }
+
+        [Test]
+        public void HttpClientFactory_Should_Create_One_Instance_Per_Dns_Success()
+        {
+
+            var httpClient = _httpClientFactory.Create(_apiUri);
+            var expectedHashId = httpClient.GetHashCode();
+
+            var newHttpClient = _httpClientFactory.Create(_newApiUri);
+            var actualHashId = newHttpClient.GetHashCode();
+
+            Assert.AreNotEqual(expectedHashId, actualHashId);
+        }
+    }
+}

--- a/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
@@ -10,6 +10,7 @@ namespace Unleash.Tests.Communication
         private Uri _newApiUri { get; } = new Uri("http://unleash2.herokuapp2.com/");
 
         private DefaultHttpClientFactory _httpClientFactory { get; } = new DefaultHttpClientFactory();
+
         [Test]
         public void HttpClientFactory_Should_Create_Single_Instance_By_Dns_Success()
         {

--- a/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
@@ -5,20 +5,19 @@ namespace Unleash.Tests.Communication
 {
     public class UnleashHttpClientFactory_RegisterHttpClient_Tests
     {
-        private Uri _apiUri { get; } = new Uri("http://unleash.herokuapp.com/");
+        private readonly Uri apiUri = new Uri("http://unleash.herokuapp.com/");
 
-        private Uri _newApiUri { get; } = new Uri("http://unleash2.herokuapp2.com/");
+        private readonly Uri newApiUri = new Uri("http://unleash2.herokuapp2.com/");
 
         private DefaultHttpClientFactory _httpClientFactory { get; } = new DefaultHttpClientFactory();
 
         [Test]
         public void HttpClientFactory_Should_Create_Single_Instance_By_Dns_Success()
         {
-
-            var httpClient = _httpClientFactory.Create(_apiUri);
+            var httpClient = _httpClientFactory.Create(apiUri);
             var expectedHashId = httpClient.GetHashCode();
 
-            var newHttpClient = _httpClientFactory.Create(_apiUri);
+            var newHttpClient = _httpClientFactory.Create(apiUri);
             var actualHashId = newHttpClient.GetHashCode();
 
             Assert.AreEqual(expectedHashId, actualHashId);
@@ -27,11 +26,10 @@ namespace Unleash.Tests.Communication
         [Test]
         public void HttpClientFactory_Should_Create_One_Instance_Per_Dns_Success()
         {
-
-            var httpClient = _httpClientFactory.Create(_apiUri);
+            var httpClient = _httpClientFactory.Create(apiUri);
             var expectedHashId = httpClient.GetHashCode();
 
-            var newHttpClient = _httpClientFactory.Create(_newApiUri);
+            var newHttpClient = _httpClientFactory.Create(newApiUri);
             var actualHashId = newHttpClient.GetHashCode();
 
             Assert.AreNotEqual(expectedHashId, actualHashId);

--- a/tests/Unleash.Tests/Unleash.Tests.csproj
+++ b/tests/Unleash.Tests/Unleash.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Communication\BaseUnleashApiClientTest.cs" />
     <Compile Include="Communication\UnleashApiClient_RegisterClient_Tests.cs" />
     <Compile Include="Communication\UnleashApiClient_SendMetrics_Tests.cs" />
+    <Compile Include="Communication\UnleashHttpClientFactory_RegisterHttpClient_Tests.cs" />
     <Compile Include="ExampleTests.cs" />
     <Compile Include="Metrics\MetricsBucketTests.cs" />
     <Compile Include="Mock\MockApiClient.cs" />


### PR DESCRIPTION
# Description

DefaultHttpClientFactory is opening a new socket for each request and its throwing a socket exception in high availability API

## Fixes

https://github.com/Unleash/unleash-client-core/issues/40

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a new test file **UnleashHttpClientFactory_RegisterHttpClient_Tests** that just validates that when we call **Create** passing an existing uri the factory will return the same instance(using hashcode) and when we call **Create** passing a new uri it will create a new instance.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules