### PR TITLE
Use compliant API URL (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
     InstanceTag = "instance z",
-    UnleashApi = new Uri("http://unleash.herokuapp.com/"),
+    UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
 };
 
 var unleash = new DefaultUnleash(settings);
@@ -142,7 +142,7 @@ var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
     InstanceTag = "instance z",
-    UnleashApi = new Uri("http://unleash.herokuapp.com/"),
+    UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     UnleashContextProvider = new AspNetContextProvider(),
 };
 ``` 
@@ -155,7 +155,7 @@ var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
     InstanceTag = "instance z",
-    UnleashApi = new Uri("http://unleash.herokuapp.com/"),
+    UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     UnleashContextProvider = new AspNetContextProvider(),
     CustomHttpHeaders = new Dictionary<string, string>()
     {
@@ -181,7 +181,7 @@ var settings = new UnleashSettings()
 {
     AppName = "dotnet-test",
     InstanceTag = "instance z",
-    UnleashApi = new Uri("http://unleash.herokuapp.com/"),
+    UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
     JsonSerializer = new NewtonsoftJson7Serializer()
 };
 

--- a/samples/WebApp/Global.asax.cs
+++ b/samples/WebApp/Global.asax.cs
@@ -24,8 +24,8 @@ namespace WebApp
 
             UnleashSettings = new UnleashSettings()
             {
-                UnleashApi = new Uri("http://unleash.herokuapp.com/"),
-                //UnleashApi = new Uri("http://localhost:4242/"),
+                UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
+                //UnleashApi = new Uri("http://localhost:4242/api/"),
                 AppName = "dotnet-api-test",
                 InstanceTag = "instance 1",
                 SendMetricsInterval = TimeSpan.FromSeconds(20),

--- a/samples/WinFormsApp/Program.cs
+++ b/samples/WinFormsApp/Program.cs
@@ -30,8 +30,8 @@ namespace WinFormsApp
 
             settings = new UnleashSettings
             {
-                UnleashApi = new Uri("http://unleash.herokuapp.com/"),
-                //UnleashApi = new Uri("http://localhost:4242/"),
+                UnleashApi = new Uri("http://unleash.herokuapp.com/api/"),
+                //UnleashApi = new Uri("http://localhost:4242/api/"),
                 AppName = "dotnet-forms-test",
                 InstanceTag = "instance 1",
                 SendMetricsInterval = TimeSpan.FromSeconds(5),

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -30,7 +30,7 @@ namespace Unleash.Communication
 
         public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
         {
-            const string resourceUri = "api/client/features";
+            const string resourceUri = "client/features";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, resourceUri))
             {
@@ -88,7 +88,7 @@ namespace Unleash.Communication
 
         public async Task<bool> RegisterClient(ClientRegistration registration, CancellationToken cancellationToken)
         {
-            const string requestUri = "api/client/register";
+            const string requestUri = "client/register";
 
             var memoryStream = new MemoryStream();
             jsonSerializer.Serialize(memoryStream, registration);
@@ -98,7 +98,7 @@ namespace Unleash.Communication
 
         public async Task<bool> SendMetrics(ThreadSafeMetricsBucket metrics, CancellationToken cancellationToken)
         {
-            const string requestUri = "api/client/metrics";
+            const string requestUri = "client/metrics";
 
             var memoryStream = new MemoryStream();
 

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -29,7 +29,7 @@ namespace Unleash
         /// <summary>
         /// Gets or set the uri for the backend unleash server.
         /// 
-        /// Default: http://unleash.herokuapp.com/
+        /// Default: http://unleash.herokuapp.com/api/
         /// </summary>
         public Uri UnleashApi { get; set; } = new Uri("http://unleash.herokuapp.com/api/");
 

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -31,7 +31,7 @@ namespace Unleash
         /// 
         /// Default: http://unleash.herokuapp.com/
         /// </summary>
-        public Uri UnleashApi { get; set; } = new Uri("http://unleash.herokuapp.com/");
+        public Uri UnleashApi { get; set; } = new Uri("http://unleash.herokuapp.com/api/");
 
         /// <summary>
         /// Gets or sets an application name. Used for communication with backend api.

--- a/tests/Unleash.Tests/Communication/BaseUnleashApiClientTest.cs
+++ b/tests/Unleash.Tests/Communication/BaseUnleashApiClientTest.cs
@@ -11,7 +11,7 @@ namespace Unleash.Tests.Communication
     {
         private static IUnleashApiClient CreateApiClient()
         {
-            var apiUri = new Uri("http://unleash.herokuapp.com/");
+            var apiUri = new Uri("http://unleash.herokuapp.com/api/");
 
             var jsonSerializer = new DynamicNewtonsoftJsonSerializer();
             jsonSerializer.TryLoad();

--- a/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
+++ b/tests/Unleash.Tests/Communication/UnleashHttpClientFactory_RegisterHttpClient_Tests.cs
@@ -5,9 +5,9 @@ namespace Unleash.Tests.Communication
 {
     public class UnleashHttpClientFactory_RegisterHttpClient_Tests
     {
-        private readonly Uri apiUri = new Uri("http://unleash.herokuapp.com/");
+        private readonly Uri apiUri = new Uri("http://unleash.herokuapp.com/api/");
 
-        private readonly Uri newApiUri = new Uri("http://unleash2.herokuapp2.com/");
+        private readonly Uri newApiUri = new Uri("http://unleash2.herokuapp2.com/api/");
 
         private readonly DefaultHttpClientFactory httpClientFactory = new DefaultHttpClientFactory();
 


### PR DESCRIPTION
Unleash API URL path /api/ shouldn't be hard-coded, as it prevents custom URLs/paths.